### PR TITLE
CPR-544 Add security context to job

### DIFF
--- a/helm_deploy/hmpps-person-match/templates/migrations.yaml
+++ b/helm_deploy/hmpps-person-match/templates/migrations.yaml
@@ -42,5 +42,7 @@ spec:
               type: RuntimeDefault
             capabilities:
               drop: ["ALL"]
+      imagePullSecrets:
+        - name: dockerconfigjson-github-com
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
* Should fix:
```
W0124 10:09:39.068275    1969 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "migrations" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "migrations" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "migrations" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "migrations" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```
* Allow job to pull image from private repo