### PR TITLE
CPR-562 multistage uv

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   migrations:
     build: .
     container_name: db-migrations
-    command: uv run alembic upgrade head
+    command: alembic upgrade head
     networks:
       - hmpps
     environment:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-source /opt/.venv/bin/activate
+source /app/.venv/bin/activate
 
 exec uvicorn \
     --host 0.0.0.0 \

--- a/helm_deploy/hmpps-person-match/templates/migrations.yaml
+++ b/helm_deploy/hmpps-person-match/templates/migrations.yaml
@@ -12,7 +12,7 @@ spec:
       containers:
         - name: migrations
           image: '{{ index .Values "generic-service" "image" "repository" }}:{{ index .Values "generic-service" "image" "tag" }}'
-          command: ["uv", "run", "alembic", "upgrade", "head"]
+          command: ["alembic", "upgrade", "head"]
           env:
             - name: DATABASE_NAME
               valueFrom:


### PR DESCRIPTION
* https://depot.dev/docs/container-builds/how-to-guides/optimal-dockerfiles/python-uv-dockerfile
* Retains multi stage build
* Activates venv so dont have to reference `uv run` when migrating