### PR TITLE
CPR-547 Use correct ssl arg for asyncpg

### DIFF
--- a/hmpps_person_match/db/__init__.py
+++ b/hmpps_person_match/db/__init__.py
@@ -8,7 +8,7 @@ from hmpps_person_match.db.config import Config
 db_query_string_params = None
 if Config.DB_SSL_ENABLED:
     db_query_string_params = {
-        "sslmode": "verify-full",
+        "ssl": "verify-full",
     }
 
 # Construct the database URL


### PR DESCRIPTION
* https://github.com/MagicStack/asyncpg/issues/737#issuecomment-1522112866
* Use `ssl` instead of `sslmode` for asyncpg