### PR TITLE
CPR-547 Make db driver configurable with options

### DIFF
--- a/hmpps_person_match/db/__init__.py
+++ b/hmpps_person_match/db/__init__.py
@@ -3,27 +3,33 @@ from collections.abc import AsyncGenerator
 from sqlalchemy import URL
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 
-from hmpps_person_match.db.config import Config
+from hmpps_person_match.db.config import Config, DatabaseDriver
 
-db_query_string_params = None
-if Config.DB_SSL_ENABLED:
-    db_query_string_params = {
-        "ssl": "verify-full",
-    }
 
-# Construct the database URL
-database_url: URL = URL.create(
-    drivername=Config.DB_ASYNC_DRIVER,
-    username=Config.DB_USER,
-    password=Config.DB_PASSWORD,
-    host=Config.DB_HOST,
-    port=Config.DB_PORT,
-    database=Config.DB_NAME,
-    query=db_query_string_params,
-)
+def build_database_url(driver: DatabaseDriver) -> URL:
+    """
+    Build database connection
+    """
+    db_query_string_params = {}
+    if Config.DB_SSL_ENABLED:
+        if driver == DatabaseDriver.ASYNC:
+            db_query_string_params["ssl"] =  "verify-full"
+        if driver == DatabaseDriver.SYNC:
+            db_query_string_params["sslmode"] =  "verify-full"
+
+    # Construct the database URL
+    return URL.create(
+        drivername=driver.value,
+        username=Config.DB_USER,
+        password=Config.DB_PASSWORD,
+        host=Config.DB_HOST,
+        port=Config.DB_PORT,
+        database=Config.DB_NAME,
+        query=db_query_string_params,
+    )
 
 engine: AsyncEngine = create_async_engine(
-    database_url,
+    build_database_url(DatabaseDriver.ASYNC),
     echo=Config.DB_LOGGING,
     pool_size=Config.DB_CON_POOL_SIZE,
     max_overflow=Config.DB_CON_POOL_MAX_OVERFLOW,

--- a/hmpps_person_match/db/config.py
+++ b/hmpps_person_match/db/config.py
@@ -1,14 +1,19 @@
 import os
+from enum import Enum
 
+
+class DatabaseDriver(str, Enum):
+    """
+    Database driver
+    """
+    SYNC = "postgresql+psycopg"
+    ASYNC = "postgresql+asyncpg"
 
 class Config:
     """
     Database configuration
     """
-
     # Database connection settings
-    DB_SYNC_DRIVER = "postgresql+psycopg"
-    DB_ASYNC_DRIVER = "postgresql+asyncpg"
     DB_USER = os.environ.get("DATABASE_USERNAME")
     DB_PASSWORD = os.environ.get("DATABASE_PASSWORD")
     DB_HOST = os.environ.get("DATABASE_HOST")

--- a/hmpps_person_match/db/migrations/env.py
+++ b/hmpps_person_match/db/migrations/env.py
@@ -3,8 +3,8 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from hmpps_person_match.db import database_url
-from hmpps_person_match.db.config import Config
+from hmpps_person_match.db import build_database_url
+from hmpps_person_match.db.config import DatabaseDriver
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -15,12 +15,8 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# Run migrations synchronously
-sync_database_url = database_url.render_as_string(hide_password=False).replace(
-    Config.DB_ASYNC_DRIVER, Config.DB_SYNC_DRIVER,
-)
 # Set the SQLAlchemy URL dynamically
-config.set_main_option("sqlalchemy.url", sync_database_url)
+config.set_main_option("sqlalchemy.url", build_database_url(DatabaseDriver.SYNC).render_as_string(hide_password=False))
 
 # add your model's MetaData object here
 # for 'autogenerate' support


### PR DESCRIPTION
* Make driver configurable depending on driver. As we use both sync and async drivers which have different arguments defined