### PR TITLE
CPR-608 Score - full model with dummy postcode tfs

### DIFF
--- a/hmpps_cpr_splink/cpr_splink/model/model.py
+++ b/hmpps_cpr_splink/cpr_splink/model/model.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-MODEL_VERSION = "model_2025_01_13_5e08_no_postcode"
+MODEL_VERSION = "model_2025_01_28_1e09"
 
 MODEL_PATH = Path(__file__).parent / f"model_files/{MODEL_VERSION}.json"
 # TODO: other metadata of use to library client?

--- a/hmpps_cpr_splink/cpr_splink/model/model_files/model_2025_01_28_1e09.json
+++ b/hmpps_cpr_splink/cpr_splink/model/model_files/model_2025_01_28_1e09.json
@@ -1,0 +1,280 @@
+{
+    "link_type": "link_and_dedupe",
+    "probability_two_random_records_match": 1.775855843245189e-06,
+    "retain_matching_columns": true,
+    "retain_intermediate_calculation_columns": true,
+    "additional_columns_to_retain": ["match_id"],
+    "sql_dialect": "duckdb",
+    "linker_uid": "836a1jpq",
+    "em_convergence": 0.0001,
+    "max_iterations": 25,
+    "bayes_factor_column_prefix": "bf_",
+    "term_frequency_adjustment_column_prefix": "tf_",
+    "comparison_vector_value_column_prefix": "gamma_",
+    "unique_id_column_name": "id",
+    "source_dataset_column_name": "source_system",
+    "blocking_rules_to_generate_predictions": ["1=1"],
+    "comparisons": [
+        {
+            "output_column_name": "name_comparison",
+            "comparison_levels": [
+                {
+                    "sql_condition": "(\"name_1_std_l\" IS NULL OR \"name_1_std_r\" IS NULL) AND (\"last_name_std_l\" IS NULL OR \"last_name_std_r\" IS NULL)",
+                    "label_for_charts": "(name_1_std is NULL) AND (last_name_std is NULL)",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "\"first_and_last_name_std_l\" = \"first_and_last_name_std_r\"",
+                    "label_for_charts": "Exact match on first_and_last_name_std",
+                    "m_probability": 0.8787963278164166,
+                    "u_probability": 7.2135433177901606e-06,
+                    "tf_adjustment_column": "first_and_last_name_std",
+                    "tf_adjustment_weight": 1.0
+                },
+                {
+                    "sql_condition": "jaro_winkler_similarity(\"first_and_last_name_std_l\", \"first_and_last_name_std_r\") >= 0.9",
+                    "label_for_charts": "Jaro-Winkler distance of first_and_last_name_std >= 0.9",
+                    "m_probability": 0.07355519002561481,
+                    "u_probability": 0.0004188206021358899,
+                    "tf_adjustment_column": "first_and_last_name_std",
+                    "tf_adjustment_weight": 0.7
+                },
+                {
+                    "sql_condition": "\"name_1_std_l\" = \"last_name_std_r\" AND \"name_1_std_r\" = \"last_name_std_l\"",
+                    "label_for_charts": "Match on reversed cols: name_1_std and last_name_std (both directions)",
+                    "m_probability": 0.0020093254595673414,
+                    "u_probability": 1.9314729853158546e-07
+                },
+                {
+                    "sql_condition": "(array_length(list_intersect(\"forename_std_arr_l\", \"forename_std_arr_r\")) >= 1) AND (array_length(list_intersect(\"last_name_std_arr_l\", \"last_name_std_arr_r\")) >= 1)",
+                    "label_for_charts": "(Array intersection size >= 1) AND (Array intersection size >= 1)",
+                    "m_probability": 0.022406418628892023,
+                    "u_probability": 1.0120918443055078e-05
+                },
+                {
+                    "sql_condition": "(jaro_winkler_similarity(\"name_1_std_l\", \"name_1_std_r\") >= 0.7) AND (jaro_winkler_similarity(\"last_name_std_l\", \"last_name_std_r\") >= 0.7)",
+                    "label_for_charts": "(Jaro-Winkler distance of name_1_std >= 0.7) AND (Jaro-Winkler distance of last_name_std >= 0.7)",
+                    "m_probability": 0.0049894943899656706,
+                    "u_probability": 0.00046154580113580575
+                },
+                {
+                    "sql_condition": "\"name_1_std_l\" = \"name_1_std_r\"",
+                    "label_for_charts": "Exact match on name_1_std",
+                    "m_probability": 0.003999813575914677,
+                    "u_probability": 0.0035909813589577585,
+                    "tf_adjustment_column": "name_1_std",
+                    "tf_adjustment_weight": 1.0
+                },
+                {
+                    "sql_condition": "\"last_name_std_l\" = \"last_name_std_r\"",
+                    "label_for_charts": "Exact match on last_name_std",
+                    "m_probability": 0.005556540474896499,
+                    "u_probability": 0.0007660384510119338,
+                    "tf_adjustment_column": "last_name_std",
+                    "tf_adjustment_weight": 1.0
+                },
+                {
+                    "sql_condition": "ELSE",
+                    "label_for_charts": "All other comparisons",
+                    "m_probability": 0.0040385598046860805,
+                    "u_probability": 0.9947450861776992
+                }
+            ],
+            "comparison_description": "CustomComparison"
+        },
+        {
+            "output_column_name": "date_of_birth_arr",
+            "comparison_levels": [
+                {
+                    "sql_condition": "\"date_of_birth_arr_l\" IS NULL OR \"date_of_birth_arr_r\" IS NULL",
+                    "label_for_charts": "date_of_birth_arr is NULL",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "\"date_of_birth_l\" = \"date_of_birth_r\"",
+                    "label_for_charts": "Exact match on date_of_birth",
+                    "m_probability": 0.9464343303141814,
+                    "u_probability": 6.324075751757724e-05,
+                    "tf_adjustment_column": "date_of_birth",
+                    "tf_adjustment_weight": 1.0
+                },
+                {
+                    "sql_condition": "\narray_length(\n    list_intersect(\"date_of_birth_arr_l\", \"date_of_birth_arr_r\")\n)\n >= 1",
+                    "label_for_charts": "Array intersection size >= 1",
+                    "m_probability": 0.016471211402646384,
+                    "u_probability": 1.7723128863141345e-05
+                },
+                {
+                    "sql_condition": "damerau_levenshtein(CAST(date_of_birth_l AS TEXT), CAST(date_of_birth_r AS TEXT)) <= 1",
+                    "label_for_charts": "Damerau-Levenshtein distance of cast(date_of_birth as varchar) <= 1",
+                    "m_probability": 0.01809148799594185,
+                    "u_probability": 0.0018144602187555058
+                },
+                {
+                    "sql_condition": "ABS(EPOCH(\"date_of_birth_l\") - EPOCH(\"date_of_birth_r\")) <= 157788000.0",
+                    "label_for_charts": "Abs difference of 'date_of_birth <= 5 year'",
+                    "m_probability": 0.00963867941781235,
+                    "u_probability": 0.21805919357485196
+                },
+                {
+                    "sql_condition": "ELSE",
+                    "label_for_charts": "All other comparisons",
+                    "m_probability": 0.00218323152870664,
+                    "u_probability": 0.7800453823200119
+                }
+            ],
+            "comparison_description": "CustomComparison"
+        },
+        {
+            "output_column_name": "postcode_arr",
+            "comparison_levels": [
+                {
+                    "sql_condition": "\"postcode_arr_l\" IS NULL OR \"postcode_arr_r\" IS NULL",
+                    "label_for_charts": "postcode_arr is NULL",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "\n    list_reduce(\n        list_prepend(\n            1.0,\n            list_transform(\n                postcode_arr_with_freq_l,\n                x -> CASE\n                        WHEN array_contains(\n                            list_transform(postcode_arr_with_freq_r, y -> y.value),\n                            x.value\n                        )\n                        THEN x.rel_freq\n                        ELSE 1.0\n                    END\n            )\n        ),\n        (p, q) -> p * q\n    ) < 0.00001",
+                    "label_for_charts": "tf arr mul < 0.00001",
+                    "m_probability": 0.6670891795591943,
+                    "u_probability": 1.294096500015498e-05
+                },
+                {
+                    "sql_condition": "\n    list_reduce(\n        list_prepend(\n            1.0,\n            list_transform(\n                postcode_arr_with_freq_l,\n                x -> CASE\n                        WHEN array_contains(\n                            list_transform(postcode_arr_with_freq_r, y -> y.value),\n                            x.value\n                        )\n                        THEN x.rel_freq\n                        ELSE 1.0\n                    END\n            )\n        ),\n        (p, q) -> p * q\n    ) < 0.0001",
+                    "label_for_charts": "tf arr mul < 0.0001",
+                    "m_probability": 0.04612205687507028,
+                    "u_probability": 7.409099972943288e-06
+                },
+                {
+                    "sql_condition": "\n    list_reduce(\n        list_prepend(\n            1.0,\n            list_transform(\n                postcode_arr_with_freq_l,\n                x -> CASE\n                        WHEN array_contains(\n                            list_transform(postcode_arr_with_freq_r, y -> y.value),\n                            x.value\n                        )\n                        THEN x.rel_freq\n                        ELSE 1.0\n                    END\n            )\n        ),\n        (p, q) -> p * q\n    ) < 0.001",
+                    "label_for_charts": "tf arr mul < 0.001",
+                    "m_probability": 0.009904417202376418,
+                    "u_probability": 5.692718054406684e-05
+                },
+                {
+                    "sql_condition": "array_length(list_intersect(\"postcode_outcode_arr_l\", \"postcode_outcode_arr_r\")) >= 1",
+                    "label_for_charts": "Array intersection size >= 1",
+                    "m_probability": 0.09150135763671098,
+                    "u_probability": 0.001943676490389979
+                },
+                {
+                    "sql_condition": "ELSE",
+                    "label_for_charts": "All other comparisons",
+                    "m_probability": 0.18281139283200534,
+                    "u_probability": 0.9979790462640928
+                }
+            ],
+            "comparison_description": "CustomComparison"
+        },
+        {
+            "output_column_name": "name_2_std",
+            "comparison_levels": [
+                {
+                    "sql_condition": "\"name_2_std_l\" IS NULL OR \"name_2_std_r\" IS NULL",
+                    "label_for_charts": "name_2_std is NULL",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "\"name_2_std_l\" = \"name_2_std_r\"",
+                    "label_for_charts": "Exact match on name_2_std",
+                    "m_probability": 0.9243762913442157,
+                    "u_probability": 0.010917836116825702,
+                    "tf_adjustment_column": "name_2_std",
+                    "tf_adjustment_weight": 1.0
+                },
+                {
+                    "sql_condition": "jaro_winkler_similarity(\"name_2_std_l\", \"name_2_std_r\") >= 0.85",
+                    "label_for_charts": "Jaro-Winkler distance of name_2_std >= 0.85",
+                    "m_probability": 0.03043418520733826,
+                    "u_probability": 0.0022673779080445954
+                },
+                {
+                    "sql_condition": "ELSE",
+                    "label_for_charts": "All other comparisons",
+                    "m_probability": 0.04518952344844608,
+                    "u_probability": 0.9868147859751297
+                }
+            ],
+            "comparison_description": "JaroWinklerAtThresholds"
+        },
+        {
+            "output_column_name": "id_comparison",
+            "comparison_levels": [
+                {
+                    "sql_condition": "\n            (cro_single_l is null or cro_single_r is null)\n            AND (pnc_single_l is null or pnc_single_r is null)\n            AND (pnc_single_l is null or cro_single_r is null)\n            AND (cro_single_l is null or pnc_single_r is null)\n            ",
+                    "label_for_charts": "\n            (cro_single_l is null or cro_single_r is null)\n            AND (pnc_single_l is null or pnc_single_r is null)\n            AND (pnc_single_l is null or cro_single_r is null)\n            AND (cro_single_l is null or pnc_single_r is null)\n            ",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "\"pnc_single_l\" = \"pnc_single_r\"",
+                    "label_for_charts": "Exact match on pnc_single",
+                    "m_probability": 0.3926077415462267,
+                    "u_probability": 1.283466477956899e-07,
+                    "tf_adjustment_column": "pnc_single",
+                    "tf_adjustment_weight": 1.0
+                },
+                {
+                    "sql_condition": "\"cro_single_l\" = \"cro_single_r\"",
+                    "label_for_charts": "Exact match on cro_single",
+                    "m_probability": 0.5031590770251514,
+                    "u_probability": 1.4028587084645174e-07,
+                    "tf_adjustment_column": "cro_single",
+                    "tf_adjustment_weight": 1.0
+                },
+                {
+                    "sql_condition": "\n            (\n                substring(pnc_single_l, 7, 6) = substring(cro_single_r, 1, 6)\n                or\n                substring(pnc_single_r, 7, 6) = substring(cro_single_l, 1, 6)\n            )\n            or\n            (\n                substring(pnc_single_l, 1, 5) = substring(pnc_single_r, 1, 5)\n                AND\n                substring(pnc_single_l, 8, 6) = substring(pnc_single_r, 8, 6)\n            )\n            ",
+                    "label_for_charts": "PNC and CRO core numbers match",
+                    "m_probability": 0.04789270283602978,
+                    "u_probability": 2.1072728684594666e-06
+                },
+                {
+                    "sql_condition": "\n            (cro_single_l is null or cro_single_r is null)\n            AND (pnc_single_l is null or pnc_single_r is null)\n            ",
+                    "label_for_charts": "\n            (cro_single_l is null or cro_single_r is null)\n            AND (pnc_single_l is null or pnc_single_r is null)\n            ",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "ELSE",
+                    "label_for_charts": "All other comparisons",
+                    "m_probability": 0.0563404785925921,
+                    "u_probability": 0.9999976240946129
+                }
+            ],
+            "comparison_description": "CustomComparison"
+        },
+        {
+            "output_column_name": "sentence_date_arr",
+            "comparison_levels": [
+                {
+                    "sql_condition": "\"sentence_date_arr_l\" IS NULL OR \"sentence_date_arr_r\" IS NULL",
+                    "label_for_charts": "sentence_date_arr is NULL",
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "array_length(list_intersect(\"sentence_date_arr_l\", \"sentence_date_arr_r\")) >= 1 and len(\"sentence_date_arr_l\") * len(\"sentence_date_arr_r\") <= 9",
+                    "label_for_charts": "Array intersection size >= 1, few elements",
+                    "m_probability": 0.4949430500483698,
+                    "u_probability": 0.0004002408608569241
+                },
+                {
+                    "sql_condition": "array_length(list_intersect(\"sentence_date_arr_l\", \"sentence_date_arr_r\")) >= 1",
+                    "label_for_charts": "Array intersection size >= 1, many elements",
+                    "m_probability": 0.2792515293964825,
+                    "u_probability": 0.0009453261897310465
+                },
+                {
+                    "sql_condition": "\n    abs(datediff('day', sentence_date_arr_l[1], sentence_date_arr_r[1])) <= 14\n    or\n    abs(datediff('day', sentence_date_arr_l[-1], sentence_date_arr_r[-1])) <= 14\n",
+                    "label_for_charts": "First or last elements within 2 weeks",
+                    "m_probability": 0.021501087653409467,
+                    "u_probability": 0.005844206681354541
+                },
+                {
+                    "sql_condition": "ELSE",
+                    "label_for_charts": "All other comparisons",
+                    "m_probability": 0.13939109937753488,
+                    "u_probability": 0.9928102262680575
+                }
+            ],
+            "comparison_description": "CustomComparison"
+        }
+    ]
+}

--- a/hmpps_cpr_splink/cpr_splink/model/score.py
+++ b/hmpps_cpr_splink/cpr_splink/model/score.py
@@ -27,7 +27,7 @@ def _mock_lookup_many_tf(value_col_pairs):
 
 
 def populate_with_tfs(con: duckdb.DuckDBPyConnection, records_table: str, real_term_frequencies: bool = True) -> str:
-    # TODO: postcodes
+
     tf_columns = [
         "name_1_std",
         "name_2_std",
@@ -50,6 +50,15 @@ def populate_with_tfs(con: duckdb.DuckDBPyConnection, records_table: str, real_t
             select_clauses.append(f"{alias_table_name}.{tf_colname} AS {tf_colname}")
         else:
             select_clauses.append(f"NULL AS {tf_colname}")
+
+    # postcodes - dummy only
+    if real_term_frequencies:
+        # TODO: real postcodes
+        pass
+    else:
+        select_clauses.append(
+            "list_transform(postcode_arr, x -> struct_pack(value := x, rel_freq := 1)) AS postcode_arr_with_freq",
+        )
 
     joined_views_name = "final_table_with_tf"
     sql_join = " ".join(join_clauses)

--- a/integration/endpoints/test_person_score.py
+++ b/integration/endpoints/test_person_score.py
@@ -82,12 +82,12 @@ class TestPersonScoreEndpoint:
         assert {
             "candidate_match_id": matching_person_id_2,
             "candidate_match_probability": 1.0,
-            "candidate_match_weight": 70.76272963361279,
+            "candidate_match_weight": 55.4382142967686,
         } in response.json()
         assert {
             "candidate_match_id": matching_person_id_1,
             "candidate_match_probability": 1.0,
-            "candidate_match_weight": 70.76272963361279,
+            "candidate_match_weight": 55.4382142967686,
         } in response.json()
 
     @staticmethod


### PR DESCRIPTION
This now uses the full model, but postcode term frequencies are all set as 1 (when we have `real_term_frequencies=False`).

Follow-up will fill in the real path where we insert the actual term frequency values.