### PR TITLE
CPR-629 Increase db connections

### DIFF
--- a/hmpps_person_match/db/config.py
+++ b/hmpps_person_match/db/config.py
@@ -18,8 +18,8 @@ class Config:
     DB_SSL_ENABLED = os.environ.get("DB_SSL_ENABLED", "True") == "True"
 
     # Database connection pool settings
-    DB_CON_POOL_SIZE = 15  # Max connections in the pool
-    DB_CON_POOL_MAX_OVERFLOW = 5  # Additional connections allowed beyond pool size
-    DB_CON_POOL_TIMEOUT = 30  # Wait time before timeout if pool is full (seconds)
+    DB_CON_POOL_SIZE = 100  # Max connections in the pool
+    DB_CON_POOL_MAX_OVERFLOW = 10  # Additional connections allowed beyond pool size
+    DB_CON_POOL_TIMEOUT = 60  # Wait time before timeout if pool is full (seconds)
     DB_CON_POOL_RECYCLE = 300  # Wait time before connection is recycled (seconds)
     DB_CON_POOL_PRE_PING = True  # Test connections before using them


### PR DESCRIPTION
* With RDS upgrade, now have a max connections of: `3484` so making pool of connection large to stop any bottlenecks, can refine once running (without breaking)