### PR TITLE
CPR-629 Rebuild indexes into single columns

### DIFF
--- a/hmpps_person_match/db/migrations/versions/e500e072471a_rebuild_indexes.py
+++ b/hmpps_person_match/db/migrations/versions/e500e072471a_rebuild_indexes.py
@@ -63,6 +63,7 @@ def downgrade() -> None:
     op.drop_index("idx_person__postcode_first", schema="personmatch")
     op.drop_index("idx_person__postcode_outcode_first", schema="personmatch")
     op.drop_index("idx_person__substring_name_1", schema="personmatch")
+    op.drop_index("idx_person__date_of_birth_last", schema="personmatch")
     op.drop_index("idx_person__postcode_outcode_last", schema="personmatch")
     op.drop_index("idx_person__last_name", schema="personmatch")
     op.drop_index("idx_person__forename_first", schema="personmatch")


### PR DESCRIPTION
* Re-build indexes into single columns (faster inserts)
* Stats on 3,500,00 record dummy data on candidate search:
   * Planning Time: ~ 7.257 ms
   * Execution Time: ~ 25.157 ms