### PR TITLE
(WIP) Fix `is-cluster-valid` nondeterministic test

### DIFF
--- a/integration/endpoints/test_is_cluster_valid.py
+++ b/integration/endpoints/test_is_cluster_valid.py
@@ -100,8 +100,9 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         await create_person_record(person_data)
 
         # Create an entirely different person
+        matching_person_id_2 = str(uuid.uuid4())
         person_data = MockPerson(
-            matchId=match_id,
+            matchId=matching_person_id_2,
             firstName="Different",
             middleNames="",
             lastName="Name",
@@ -113,11 +114,6 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
             cros=["11/654321Z"],
             pncs=["11/7654321Z"],
             sentenceDates=["2000-03-02"],
-        )
-        matching_person_id_2 = str(uuid.uuid4())
-        person_data = MockPerson(
-            matchId=matching_person_id_2,
-            sourceSystemId=random_test_data.random_source_system_id(),
         )
         await create_person_record(person_data)
 


### PR DESCRIPTION
The test `test_is_cluster_valid_identifies_multiple_clusters` currently fails on occasion. It is somewhat unpredictable, and hard to recreate locally. [Here is an example failure](https://github.com/ministryofjustice/hmpps-person-match/actions/runs/15046180835/job/42289184068#step:6:2342).

The failure that occurs is that instead of two duplicate records (a & b) being clustered together, and a third record (c) being separate, all three are put into separate clusters. The fundamental issue is that (occasionally) identical records (up to their `match_id`) are not being scored above the clustering threshold.

From investigation into the data, this is occurring due to those records receiving term-frequencies of `1.0` in some fields, and thus very low Bayes factors for these tf-adjustments (e.g. in one example `"bf_tf_adj_name_comparison": 6.4416737775260826e-06`, which corresponds to a match-weight adjustment of -17).

Here's how I believe this is occurring. The sequence of events in the test is:
* Pre-test fixture triggered
  * Call refresh term frequency endpoint, receive 200
  * Check that each tf table is empty, asynchronously
* Start test proper
  * create person a
  * create duplicate person b (identical pii to a)
  * create distinct person c
  * call is-cluster valid, should get (a, b), (c)

What _can_ happen is that things can occur in this order:
* tf refresh call is made
* we create person a
* the async task _actually_ refreshes the tf tables - person a’s data is now in there, and appears really common (as they are 100% of values)
* a and b no longer match above the threshold, because the massively -ve tf adjustments (and this varies depending on which tf tables were refreshed before/after person creation)
* test fails because we get (a), (b), (c)