### PR TITLE
CPR-79 Enable scaling on memory

### DIFF
--- a/helm_deploy/hmpps-person-match/values.yaml
+++ b/helm_deploy/hmpps-person-match/values.yaml
@@ -6,6 +6,7 @@ generic-service:
     minReplicas: 2
     maxReplicas: 4
     targetCPUUtilizationPercentage: 75
+    targetMemoryUtilizationPercentage: 75
 
   resources:
     limits:


### PR DESCRIPTION
* it should never reach these levels, but enabling scaling to reduce downtime / failed calls