### PR TITLE
FIX: get rid of warning on each deployment

### DIFF
--- a/helm_deploy/hmpps-person-match/templates/generate-term-frequencies-cron.yaml
+++ b/helm_deploy/hmpps-person-match/templates/generate-term-frequencies-cron.yaml
@@ -19,6 +19,14 @@ spec:
           containers:
             - name: generate-term-frequencies-job
               image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              securityContext:
+                capabilities:
+                  drop:
+                  - ALL
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                seccompProfile:
+                  type: RuntimeDefault
               args:
                 - /bin/sh
                 - -c


### PR DESCRIPTION
Attempting to fix this:

> I0618 10:13:02.629263    2236 warnings.go:110] "Warning: would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"generate-term-frequencies-job\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"generate-term-frequencies-job\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"generate-term-frequencies-job\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"generate-term-frequencies-job\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
> Release "hmpps-person-match" has been upgraded. Happy Helming!


https://github.com/ministryofjustice/hmpps-person-match/actions/runs/15729778841/job/44328935126