### PR TITLE
Restore 'remove redundant cluster scoring'

### DIFF
--- a/hmpps_cpr_splink/cpr_splink/model/score.py
+++ b/hmpps_cpr_splink/cpr_splink/model/score.py
@@ -20,16 +20,14 @@ def score(
     # Compare records
     db_api = DuckDBAPI(connection_duckdb)
 
-    full_table_name = full_candidates_tn
-
     # Splink has a limitation around caching SQL - this choice of names is a workaround until we update
     # need this so that we can keep cached SQL
     source_name = "records_l_with_postcode_tfs"
     candidates_name = "records_r_with_postcode_tfs"
     # cannot create views with prepared statements: https://github.com/duckdb/duckdb/issues/13069
-    source_sql = f"CREATE TABLE {source_name} AS SELECT * FROM {full_table_name} WHERE match_id = $primary_record_id"  # noqa: S608
+    source_sql = f"CREATE TABLE {source_name} AS SELECT * FROM {full_candidates_tn} WHERE match_id = $primary_record_id"  # noqa: S608
     candidates_sql = (
-        f"CREATE TABLE {candidates_name} AS SELECT * FROM {full_table_name} WHERE match_id != $primary_record_id"  # noqa: S608
+        f"CREATE TABLE {candidates_name} AS SELECT * FROM {full_candidates_tn} WHERE match_id != $primary_record_id"  # noqa: S608
     )
     connection_duckdb.execute(source_sql, parameters={"primary_record_id": primary_record_id})
     connection_duckdb.execute(candidates_sql, parameters={"primary_record_id": primary_record_id})
@@ -39,7 +37,7 @@ def score(
         candidates_name,
         settings=MODEL_PATH,
         db_api=db_api,
-        use_sql_from_cache=True,
+        sql_cache_key="score_records_sql",
     ).as_duckdbpyrelation()
 
     end_time = time.perf_counter()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = []
 
 requires-python = ">=3.12,<3.13"
 dependencies = [
-  "splink==4.0.7",
+  "splink==4.0.8",
   "duckdb==1.3.1",
   "psycopg[binary]==3.2.9",
   "pytz==2025.2",

--- a/uv.lock
+++ b/uv.lock
@@ -505,7 +505,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = "==3.2.9" },
     { name = "pyjwt", specifier = "==2.10.1" },
     { name = "pytz", specifier = "==2025.2" },
-    { name = "splink", specifier = "==4.0.7" },
+    { name = "splink", specifier = "==4.0.8" },
     { name = "uvicorn", specifier = "==0.35.0" },
 ]
 
@@ -1533,7 +1533,7 @@ wheels = [
 
 [[package]]
 name = "splink"
-version = "4.0.7"
+version = "4.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "altair" },
@@ -1545,9 +1545,9 @@ dependencies = [
     { name = "pandas" },
     { name = "sqlglot" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/d0/b8e4bf9a2b1beb1cc41f083901791c3f5668217c0e2f70cfaa604eb790b6/splink-4.0.7.tar.gz", hash = "sha256:939404d239323308832bc5ebd0d5244fb82fb04e3bfb3d1b592ac38cbfa87c4d", size = 3657016, upload-time = "2025-03-05T08:57:23.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/21/2a82f219baa28152c2277e548fba045de599fdb0ec1e651a7e5296fbfe74/splink-4.0.8.tar.gz", hash = "sha256:84f4ad5a1d86c42837de60b662904c74ba27b1a8c6dde2042551dcc57ade5f25", size = 4830864, upload-time = "2025-06-04T13:50:06.387Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/5d/2da96b1d6af0803b342fdcbb959ba6b32c0684f4af92ad83b6a6f3690357/splink-4.0.7-py3-none-any.whl", hash = "sha256:320d0c70d02992ebc3bfa33903d35f073f4edaafea5344bc3f871ccb8b0abadb", size = 3726158, upload-time = "2025-03-05T08:57:21.099Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/fe/a73dba7b3d7850bdaa3e2e997c55981c9e2f87b1091685f5a20d83d41ed3/splink-4.0.8-py3-none-any.whl", hash = "sha256:fbba32b8065d523e8ab56b46009dcd3d1d627a7641e8b06f14aadd381aaa9f0e", size = 4900528, upload-time = "2025-06-04T13:50:04.022Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Reverts #280, reinstating the changes from #275, now that we have rollback procedures in place.