### PR TITLE
Is cluster valid - optional threshold parameter

### DIFF
--- a/hmpps_cpr_splink/cpr_splink/interface/score.py
+++ b/hmpps_cpr_splink/cpr_splink/interface/score.py
@@ -14,7 +14,6 @@ from hmpps_cpr_splink.cpr_splink.interface.clusters import Clusters
 from hmpps_cpr_splink.cpr_splink.interface.db import duckdb_connected_to_postgres
 from hmpps_cpr_splink.cpr_splink.model.model import (
     FRACTURE_MATCH_WEIGHT_THRESHOLD,
-    IS_CLUSTER_VALID_MATCH_WEIGHT_THRESHOLD,
     JOINING_MATCH_WEIGHT_THRESHOLD,
     MODEL_PATH,
 )
@@ -196,6 +195,7 @@ def get_mutually_excluded_records(
 
 async def get_clusters(
     match_ids: list[str],
+    match_weight_threshold: float,
     pg_db_url: URL,
     connection_pg: AsyncSession,
     default_postcode_tf: float = 1.0,
@@ -244,7 +244,7 @@ async def get_clusters(
             edges=scores_with_twins_table_name,
             db_api=db_api,
             node_id_column_name="match_id",
-            threshold_match_weight=IS_CLUSTER_VALID_MATCH_WEIGHT_THRESHOLD,
+            threshold_match_weight=match_weight_threshold,
         )
         clusters = connection_duckdb.execute(
             f"SELECT match_id, cluster_id FROM {df_clusters.physical_name} "  # noqa: S608

--- a/hmpps_person_match/models/cluster/is_cluster_valid.py
+++ b/hmpps_person_match/models/cluster/is_cluster_valid.py
@@ -1,8 +1,13 @@
 from pydantic import BaseModel, Field
 
+from hmpps_cpr_splink.cpr_splink.model.model import IS_CLUSTER_VALID_MATCH_WEIGHT_THRESHOLD
+
 
 class IsClusterValidRequest(BaseModel):
-    match_ids: list[str] = Field(alias="matchIds", examples=["ea59b57f-f3b6-4f77-88dd-64f86d37dffd"])
+    match_ids: list[str] = Field(alias="matchIds", examples=[["ea59b57f-f3b6-4f77-88dd-64f86d37dffd"]])
+    clustering_threshold: float = Field(
+        default=IS_CLUSTER_VALID_MATCH_WEIGHT_THRESHOLD, alias="clusteringThreshold", examples=[21.0],
+    )
 
 
 class IsClusterValid(BaseModel):

--- a/hmpps_person_match/models/cluster/is_cluster_valid.py
+++ b/hmpps_person_match/models/cluster/is_cluster_valid.py
@@ -1,6 +1,10 @@
 from pydantic import BaseModel, Field
 
 
+class IsClusterValidRequest(BaseModel):
+    match_ids: list[str] = Field(alias="matchIds", examples=["ea59b57f-f3b6-4f77-88dd-64f86d37dffd"])
+
+
 class IsClusterValid(BaseModel):
     is_cluster_valid: bool = Field(alias="isClusterValid", examples=[False])
     clusters: list[list[str]] = Field(

--- a/hmpps_person_match/routes/cluster/is_cluster_valid.py
+++ b/hmpps_person_match/routes/cluster/is_cluster_valid.py
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Annotated
 
-from fastapi import APIRouter, Body, Depends, status
+from fastapi import APIRouter, Depends, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,7 +11,7 @@ from hmpps_person_match.dependencies.auth.jwt_bearer import JWTBearer
 from hmpps_person_match.dependencies.logger.log import get_logger
 from hmpps_person_match.domain.roles import Roles
 from hmpps_person_match.domain.telemetry_events import TelemetryEvents
-from hmpps_person_match.models.cluster.is_cluster_valid import IsClusterValid, MissingRecordIds
+from hmpps_person_match.models.cluster.is_cluster_valid import IsClusterValidRequest, IsClusterValid, MissingRecordIds
 
 ROUTE = "/is-cluster-valid"
 
@@ -34,7 +34,7 @@ router = APIRouter(
 
 @router.post(ROUTE, description=DESCRIPTION)
 async def get_cluster_validity(
-    match_ids: Annotated[list[str], Body(examples=["ea59b57f-f3b6-4f77-88dd-64f86d37dffd"])],
+    cluster_request: IsClusterValidRequest,
     session: Annotated[AsyncSession, Depends(get_db_session)],
     logger: Annotated[Logger, Depends(get_logger)],
 ) -> IsClusterValid:
@@ -43,6 +43,7 @@ async def get_cluster_validity(
     Returns an indication of whether all supplied match_ids belong to the same cluster,
     as well as the cluster groupings for casese where they don't
     """
+    match_ids = cluster_request.match_ids
     missing_ids = await score.get_missing_record_ids(match_ids, session)
     if not missing_ids:
         clusters_info = await score.get_clusters(match_ids, url.pg_database_url, session)

--- a/hmpps_person_match/routes/cluster/is_cluster_valid.py
+++ b/hmpps_person_match/routes/cluster/is_cluster_valid.py
@@ -11,7 +11,7 @@ from hmpps_person_match.dependencies.auth.jwt_bearer import JWTBearer
 from hmpps_person_match.dependencies.logger.log import get_logger
 from hmpps_person_match.domain.roles import Roles
 from hmpps_person_match.domain.telemetry_events import TelemetryEvents
-from hmpps_person_match.models.cluster.is_cluster_valid import IsClusterValidRequest, IsClusterValid, MissingRecordIds
+from hmpps_person_match.models.cluster.is_cluster_valid import IsClusterValid, IsClusterValidRequest, MissingRecordIds
 
 ROUTE = "/is-cluster-valid"
 
@@ -46,7 +46,12 @@ async def get_cluster_validity(
     match_ids = cluster_request.match_ids
     missing_ids = await score.get_missing_record_ids(match_ids, session)
     if not missing_ids:
-        clusters_info = await score.get_clusters(match_ids, url.pg_database_url, session)
+        clusters_info = await score.get_clusters(
+            match_ids,
+            cluster_request.clustering_threshold,
+            url.pg_database_url,
+            session,
+        )
         logger.info(
             TelemetryEvents.IS_CLUSTER_VALID,
             extra=dict(isClusterValid=clusters_info.is_single_cluster, clusters=str(clusters_info.clusters_groupings)),

--- a/hmpps_person_match/routes/cluster/tests/test_is_cluster_valid.py
+++ b/hmpps_person_match/routes/cluster/tests/test_is_cluster_valid.py
@@ -48,7 +48,9 @@ class TestIsClusterValidRoute:
         match_id_2 = str(uuid.uuid4())
         mock_ids_check.return_value = [match_id_1]
 
-        data = [match_id_1, match_id_2]
+        data = {
+            "matchIds": [match_id_1, match_id_2],
+        }
         response = call_endpoint(
             "post",
             ROUTE,
@@ -73,7 +75,9 @@ class TestIsClusterValidRoute:
         mock_ids_check.return_value = []
         mock_cluster_results.return_value = Clusters([[match_id_1, match_id_2]])
 
-        data = [match_id_1, match_id_2]
+        data = {
+            "matchIds": [match_id_1, match_id_2],
+        }
         response = call_endpoint(
             "post",
             ROUTE,
@@ -109,7 +113,9 @@ class TestIsClusterValidRoute:
         mock_ids_check.return_value = []
         mock_cluster_results.return_value = Clusters([[match_id_1, match_id_2], [match_id_3]])
 
-        data = [match_id_1, match_id_2, match_id_3]
+        data = {
+            "matchIds": [match_id_1, match_id_2, match_id_3],
+        }
         response = call_endpoint(
             "post",
             ROUTE,

--- a/integration/data_science/test_twins.py
+++ b/integration/data_science/test_twins.py
@@ -5,6 +5,7 @@ from sqlalchemy import URL
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from hmpps_cpr_splink.cpr_splink.interface.score import get_clusters, get_scored_candidates
+from hmpps_cpr_splink.cpr_splink.model.model import IS_CLUSTER_VALID_MATCH_WEIGHT_THRESHOLD
 from integration.mock_person import MockPerson
 from integration.person_factory import PersonFactory
 from integration.test_base import IntegrationTestBase
@@ -268,5 +269,11 @@ class TestTwinDetection(IntegrationTestBase):
             )
         # use a high postcode default tf so that we match more highly - effectively making
         # the random postcodes we use 'rare'
-        clusters = await get_clusters(person_ids, pg_db_url, db_connection, default_postcode_tf=0.000001)
+        clusters = await get_clusters(
+            person_ids,
+            IS_CLUSTER_VALID_MATCH_WEIGHT_THRESHOLD,
+            pg_db_url,
+            db_connection,
+            default_postcode_tf=0.000001,
+        )
         assert clusters.is_single_cluster == (not expected_flagged_as_twins)

--- a/integration/endpoints/test_is_cluster_valid.py
+++ b/integration/endpoints/test_is_cluster_valid.py
@@ -31,7 +31,7 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         Test is cluster valid handles an unknown match id
         """
         match_id = random_test_data.random_match_id()
-        response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=[match_id])
+        response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json={"matchIds": [match_id]})
         assert response.status_code == 404
         assert response.json() == {"unknownIds": [match_id]}
 
@@ -40,7 +40,7 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         Test is cluster valid handles non uuid match_id
         """
         match_id = "invalid_!!id123"
-        response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=[match_id])
+        response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json={"matchIds": [match_id]})
         assert response.status_code == 404
         assert response.json() == {"unknownIds": [match_id]}
 
@@ -62,7 +62,9 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         person_3 = await person_factory.create_from(person_1)
 
         # Call is-cluster-valid endpoint - should all be in same cluster
-        data = [person_1.match_id, person_2.match_id, person_3.match_id]
+        data = {
+            "matchIds": [person_1.match_id, person_2.match_id, person_3.match_id],
+        }
 
         response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=data)
         assert response.status_code == 200
@@ -95,7 +97,9 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         person_3 = await person_factory.create_from(MockPerson())
 
         # Call is-cluster-valid endpoint - should all be in same cluster
-        data = [person_1.match_id, person_2.match_id, person_3.match_id]
+        data = {
+            "matchIds": [person_1.match_id, person_2.match_id, person_3.match_id],
+        }
 
         response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=data)
         assert response.status_code == 200
@@ -137,7 +141,9 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         person_data.override_scopes = [scope]
         person_3 = await person_factory.create_from(person_data)
 
-        data = [person_1.match_id, person_2.match_id, person_3.match_id]
+        data = {
+            "matchIds": [person_1.match_id, person_2.match_id, person_3.match_id],
+        }
         response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=data)
         assert response.status_code == 200
         response_data = response.json()
@@ -169,7 +175,9 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         person_data.override_scopes = [self.new_scope()]
         person_3 = await person_factory.create_from(person_data)
 
-        data = [person_1.match_id, person_2.match_id, person_3.match_id]
+        data = {
+            "matchIds": [person_1.match_id, person_2.match_id, person_3.match_id],
+        }
         response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=data)
         assert response.status_code == 200
         response_data = response.json()
@@ -196,7 +204,9 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         non_matching_person_3 = await person_factory.create_from(MockPerson())
 
         # Call is-cluster-valid endpoint - should all be in same cluster
-        record_match_ids_data = [person_1.match_id, non_matching_person_2.match_id, non_matching_person_3.match_id]
+        record_match_ids_data = {
+            "matchIds": [person_1.match_id, non_matching_person_2.match_id, non_matching_person_3.match_id],
+        }
 
         response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=record_match_ids_data)
         assert response.status_code == 200
@@ -266,7 +276,9 @@ class TestIsClusterValidEndpoint(IntegrationTestBase):
         assert score_response_data[0]["unadjusted_match_weight"] > 18
 
         # now check that is-cluster-valid rejects the cluster
-        data = [person_1.match_id, person_2.match_id]
+        data = {
+            "matchIds": [person_1.match_id, person_2.match_id],
+        }
         response = call_endpoint("post", ROUTE, client=Client.HMPPS_PERSON_MATCH, json=data)
         assert response.status_code == 200
         response_data = response.json()


### PR DESCRIPTION


We can't have any downtime and it would be better not to have to coordinate the releases. One way to achieve this would be to leave the existing endpoint in place and add a new one alongside it which takes the new request object with the threshold. This looks like it would be fairly straightforward

 
weird-  it looks like I edited your comment, but there was no comment here

This kind of thing is what I mean - I branched off this branch: 
https://github.com/ministryofjustice/hmpps-person-match/pull/659

Having thought about this further, unless there is a very solid reason to do so we do not want to expose an additional endpoint, and we also cannot see a reason why we should want to pass in the threshold.
Can the desired behaviour be achieved in another way? What are the use cases for it?
Testing at a lower level? Perhaps a small CLI?
Let's talk when you get back