### PR TITLE
FIX: automatic lock file updates disabled and attempt to get dependen…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>ministryofjustice/hmpps-renovate-config:base.json"],
-  "lockFileMaintenance": { "enabled": true }
+  "packageRules": [
+    {
+      "matchCategories": ["python"],
+      "stabilityDays": 3
+    }
+  ]
 }


### PR DESCRIPTION
…cy updates after 3 days

Processing all the package lock version bumps is hard enough already, but now we need to wait at least 3 days before merging dependencies there is no sense in continuing with it